### PR TITLE
Add URL as Sitelinks field

### DIFF
--- a/models.go
+++ b/models.go
@@ -89,6 +89,7 @@ type SiteLink struct {
 	Site   string   `json:"site"`
 	Title  string   `json:"title"`
 	Badges []string `json:"badges"`
+	URL    string   `json:"url"`
 }
 
 // Claim represents wikidata claims data


### PR DESCRIPTION
As mentioned in https://www.wikidata.org/w/api.php?action=help&modules=wbgetentities (wikidata wbgetentities API), if we pass `sitelinks/urls` as one of the props, the returned sitelinks will have URL field.

The said URL field is not available in Sitelink struct causing us can not access the value.

This PR basically add the said field so we can access the URL value.